### PR TITLE
Add parameter for follow redirect url

### DIFF
--- a/url-status-checker.py
+++ b/url-status-checker.py
@@ -68,7 +68,7 @@ async def main():
         print("No input provided. Use -d or -l option.")
         return
 
-    async with httpx.AsyncClient() as session:
+    async with httpx.AsyncClient(follow_redirects=True) as session:
         results = {}
         tasks = [check_url_status(session, url_id, url) for url_id, url in enumerate(urls)]
         if len(urls) > 1:


### PR DESCRIPTION
This update enhances the URL scanning process by providing the exact HTTP status code instead of just the redirect status code (e.g., 301). For instance, currently, when scanning google.com without following redirects, a 301 status code is returned. With this update, you will receive a 200 HTTP status code, providing more precise information.

Changes:
Improved URL scanning to return the exact HTTP status code.
Screenshots attached for reference.

Before
![image](https://github.com/BLACK-SCORP10/url-status-checker/assets/22233083/b2409071-8434-48a4-bd96-fd455831382d)
After
![image](https://github.com/BLACK-SCORP10/url-status-checker/assets/22233083/64f48b0b-88e2-4801-8a6b-d5d4fdb6b8df)
